### PR TITLE
Remove Blog heading from blog page

### DIFF
--- a/app/blog/BlogList.tsx
+++ b/app/blog/BlogList.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { BlogPostCard } from '@/components/BlogPostCard';
 import { BlogEmptyState } from '@/components/BlogEmptyState';
-import { Container, Box, Typography, Stack, Button } from '@mui/material';
+import { Container, Box, Stack, Button } from '@mui/material';
 import type { PostData } from '@/lib/posts';
 
 const POSTS_PER_PAGE = 10;
@@ -36,19 +36,6 @@ export function BlogList({ posts }: BlogListProps) {
       }}
     >
       <Container maxWidth="md" component="section" sx={{ py: 6, pb: 10 }}>
-        <Typography
-          variant="h4"
-          component="h2"
-          gutterBottom
-          sx={{
-            mb: 4,
-            fontWeight: 400,
-            letterSpacing: '-0.02em'
-          }}
-        >
-          Blog
-        </Typography>
-
         <Stack spacing={2}>
           {posts.slice(0, displayCount).map((post) => (
             <BlogPostCard


### PR DESCRIPTION
## Summary
- Removed the "Blog" heading at the top of the blog list page
- Cleaned up unused Typography import from Material-UI

## Changes
- `app/blog/BlogList.tsx`: Removed redundant "Blog" heading component and its import

## Reason
The page context is already clear from the navigation and URL, making the heading redundant. This provides a cleaner, more minimal design for the blog page.

## Test plan
- [ ] Visit the blog page and verify the heading is removed
- [ ] Check that blog posts are still displayed correctly
- [ ] Verify no TypeScript errors or warnings

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)