### PR TITLE
Remove: Recent posts section from top page

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,19 +1,12 @@
 'use client';
 
 import { HeroSection } from '@/components/HeroSection';
-import { RecentPostsSection } from '@/components/RecentPostsSection';
 import { heroContent } from '@/data/profile';
-import type { PostData } from '@/lib/posts';
 
-interface HomeClientProps {
-  recentPosts: PostData[];
-}
-
-export default function HomeClient({ recentPosts }: HomeClientProps) {
+export default function HomeClient() {
   return (
     <div>
       <HeroSection content={heroContent} />
-      <RecentPostsSection posts={recentPosts} />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,5 @@
-import { getSortedPostsData } from '@/lib/posts';
 import HomeClient from './HomeClient';
 
 export default function Home() {
-  const recentPosts = getSortedPostsData().slice(0, 3);
-
-  return <HomeClient recentPosts={recentPosts} />;
+  return <HomeClient />;
 }


### PR DESCRIPTION
## Summary
- Removed recent posts section from top page (HomeClient.tsx)
- Removed related data fetching logic from page.tsx
- Improved mobile viewing experience by reducing visual density

## Changes
- Removed `RecentPostsSection` component from `HomeClient.tsx`
- Removed `recentPosts` data fetching from `app/page.tsx`
- Removed unused imports and props

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)