### PR TITLE
Fix: Make blog entry heights uniform by preventing title wrapping

### DIFF
--- a/components/BlogPostCard.tsx
+++ b/components/BlogPostCard.tsx
@@ -31,6 +31,9 @@ export function BlogPostCard({ slug, title, date }: BlogPostCardProps) {
               textDecoration: 'underline',
             },
             transition: 'all 0.2s',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
           }}
         >
           {title}


### PR DESCRIPTION
## Summary
- ブログページのentryの高さを統一するため、タイトルが改行されないように修正しました
- タイトルに `overflow: hidden`, `textOverflow: ellipsis`, `whiteSpace: nowrap` を追加
- 長いタイトルは省略記号(...)で表示されるようになりました

## Test plan
- [x] ビルドが成功することを確認
- [x] ブログページで全てのentryの高さが統一されていることを確認

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)