### PR TITLE
Fix: Remove Tailwind CSS references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Next.js + React + TypeScriptで実装した個人サイト
 - **React 19**
 - **TypeScript**
 - **Material-UI (MUI) v7**
-- **Tailwind CSS v4**
 - **Markdown** (gray-matter + remark)
 
 ## セットアップ
@@ -167,4 +166,4 @@ const navLinks = [
 ## スタイルのカスタマイズ
 
 - `app/globals.css` - グローバルスタイル
-- 各コンポーネントファイル - Material-UIのSxPropsとTailwind CSS
+- 各コンポーネントファイル - Material-UIのSxProps


### PR DESCRIPTION
## Summary
- READMEの技術スタック一覧からTailwind CSS v4を削除
- スタイルカスタマイズセクションからTailwind CSSの記載を削除

## Background
プロジェクトではTailwind CSSは使用していないため、READMEから記載を削除しました。

## Changes
- 技術スタックセクション: `- **Tailwind CSS v4**` を削除
- スタイルのカスタマイズセクション: `Material-UIのSxPropsとTailwind CSS` → `Material-UIのSxProps` に修正

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)