### PR TITLE
Fix: Remove Hugo reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ npm run build
 
 `.github/workflows/deploy.yml` に設定済みです。
 
-Hugo ベースの旧サイトは `legacy-hugo` ブランチで参照できます。
-
 ## コンテンツの編集
 
 ### プロフィール情報


### PR DESCRIPTION
## Summary
- READMEからHugo（legacy-hugoブランチ）に関する記述を削除

## Test plan
- [x] READMEを確認し、Hugo関連の記述が削除されていることを確認

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)