### PR TITLE
refactor: サイト設定をconfigファイルで一元管理

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getPostData, getAllPostSlugs } from '@/lib/posts';
 import Link from 'next/link';
 import { Container, Box, Typography, Link as MuiLink } from '@mui/material';
 import type { Metadata } from 'next';
+import { siteConfig } from '@/config/site';
 
 interface PageProps {
   params: { slug: string };
@@ -18,25 +19,25 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = params;
   const post = await getPostData(slug);
 
-  const title = `${post.title} | tax_free`;
+  const title = `${post.title} | ${siteConfig.name}`;
   const description = post.description || post.title;
-  const url = `https://taxfree.dev/blog/${slug}`;
+  const url = `${siteConfig.url}/blog/${slug}`;
 
   return {
     title,
     description,
     openGraph: {
       type: 'article',
-      locale: 'ja_JP',
+      locale: siteConfig.locale,
       url,
       title,
       description,
-      siteName: 'tax_free',
+      siteName: siteConfig.name,
       images: [
         {
-          url: '/icon.png',
-          width: 1706,
-          height: 1669,
+          url: siteConfig.ogImage.url,
+          width: siteConfig.ogImage.width,
+          height: siteConfig.ogImage.height,
           alt: post.title,
         },
       ],
@@ -44,11 +45,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     twitter: {
       card: 'summary_large_image',
-      site: '@taxfree_python',
-      creator: '@taxfree_python',
+      site: siteConfig.social.twitter,
+      creator: siteConfig.social.twitter,
       title,
       description,
-      images: ['/icon.png'],
+      images: [siteConfig.ogImage.url],
     },
   };
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,33 +1,36 @@
 import { getSortedPostsData } from '@/lib/posts';
 import { BlogList } from './BlogList';
 import type { Metadata } from 'next';
+import { siteConfig } from '@/config/site';
+
+const blogDescription = 'Technical blog posts about software engineering, AI, and optimization';
 
 export const metadata: Metadata = {
-  title: 'Blog - tax_free',
-  description: 'Technical blog posts about software engineering, AI, and optimization',
+  title: `Blog - ${siteConfig.name}`,
+  description: blogDescription,
   openGraph: {
     type: 'website',
-    locale: 'ja_JP',
-    url: 'https://taxfree.dev/blog',
-    title: 'Blog - tax_free',
-    description: 'Technical blog posts about software engineering, AI, and optimization',
-    siteName: 'tax_free',
+    locale: siteConfig.locale,
+    url: `${siteConfig.url}/blog`,
+    title: `Blog - ${siteConfig.name}`,
+    description: blogDescription,
+    siteName: siteConfig.name,
     images: [
       {
-        url: '/icon.png',
-        width: 1706,
-        height: 1669,
-        alt: 'tax_free Blog',
+        url: siteConfig.ogImage.url,
+        width: siteConfig.ogImage.width,
+        height: siteConfig.ogImage.height,
+        alt: `${siteConfig.name} Blog`,
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    site: '@taxfree_python',
-    creator: '@taxfree_python',
-    title: 'Blog - tax_free',
-    description: 'Technical blog posts about software engineering, AI, and optimization',
-    images: ['/icon.png'],
+    site: siteConfig.social.twitter,
+    creator: siteConfig.social.twitter,
+    title: `Blog - ${siteConfig.name}`,
+    description: blogDescription,
+    images: [siteConfig.ogImage.url],
   },
 };
 

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -2,34 +2,37 @@ import { Metadata } from 'next';
 import { getProjectsAndActivities } from '@/lib/activities';
 import { getSkillsData } from '@/lib/skills';
 import { certificationsContent } from '@/data/profile';
+import { siteConfig } from '@/config/site';
 import CVClient from './CVClient';
 
+const cvDescription = 'Curriculum Vitae - Skills, Experience, and Certifications';
+
 export const metadata: Metadata = {
-  title: 'CV - tax_free',
-  description: 'Curriculum Vitae - Skills, Experience, and Certifications',
+  title: `CV - ${siteConfig.name}`,
+  description: cvDescription,
   openGraph: {
     type: 'profile',
-    locale: 'ja_JP',
-    url: 'https://taxfree.dev/cv',
-    title: 'CV - tax_free',
-    description: 'Curriculum Vitae - Skills, Experience, and Certifications',
-    siteName: 'tax_free',
+    locale: siteConfig.locale,
+    url: `${siteConfig.url}/cv`,
+    title: `CV - ${siteConfig.name}`,
+    description: cvDescription,
+    siteName: siteConfig.name,
     images: [
       {
-        url: '/icon.png',
-        width: 1706,
-        height: 1669,
-        alt: 'tax_free CV',
+        url: siteConfig.ogImage.url,
+        width: siteConfig.ogImage.width,
+        height: siteConfig.ogImage.height,
+        alt: `${siteConfig.name} CV`,
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    site: '@taxfree_python',
-    creator: '@taxfree_python',
-    title: 'CV - tax_free',
-    description: 'Curriculum Vitae - Skills, Experience, and Certifications',
-    images: ['/icon.png'],
+    site: siteConfig.social.twitter,
+    creator: siteConfig.social.twitter,
+    title: `CV - ${siteConfig.name}`,
+    description: cvDescription,
+    images: [siteConfig.ogImage.url],
   },
 };
 

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,33 +1,36 @@
 import { Metadata } from 'next';
 import { GallerySection } from '@/components/GallerySection';
 import { getGalleryData } from '@/lib/gallery';
+import { siteConfig } from '@/config/site';
+
+const galleryDescription = 'Artwork and creative projects gallery';
 
 export const metadata: Metadata = {
-  title: 'Gallery - tax_free',
-  description: 'Artwork and creative projects gallery',
+  title: `Gallery - ${siteConfig.name}`,
+  description: galleryDescription,
   openGraph: {
     type: 'website',
-    locale: 'ja_JP',
-    url: 'https://taxfree.dev/gallery',
-    title: 'Gallery - tax_free',
-    description: 'Artwork and creative projects gallery',
-    siteName: 'tax_free',
+    locale: siteConfig.locale,
+    url: `${siteConfig.url}/gallery`,
+    title: `Gallery - ${siteConfig.name}`,
+    description: galleryDescription,
+    siteName: siteConfig.name,
     images: [
       {
-        url: '/icon.png',
-        width: 1706,
-        height: 1669,
-        alt: 'tax_free Gallery',
+        url: siteConfig.ogImage.url,
+        width: siteConfig.ogImage.width,
+        height: siteConfig.ogImage.height,
+        alt: `${siteConfig.name} Gallery`,
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    site: '@taxfree_python',
-    creator: '@taxfree_python',
-    title: 'Gallery - tax_free',
-    description: 'Artwork and creative projects gallery',
-    images: ['/icon.png'],
+    site: siteConfig.social.twitter,
+    creator: siteConfig.social.twitter,
+    title: `Gallery - ${siteConfig.name}`,
+    description: galleryDescription,
+    images: [siteConfig.ogImage.url],
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ThemeRegistry } from "@/components/ThemeRegistry";
 import { Header } from "@/components/Header";
+import { siteConfig } from "@/config/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -15,35 +16,35 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://taxfree.dev'),
-  title: "tax_free",
-  description: "Software Engineer & Researcher at Science Tokyo",
+  metadataBase: new URL(siteConfig.url),
+  title: siteConfig.name,
+  description: siteConfig.description,
   icons: {
-    icon: "/icon.png",
+    icon: siteConfig.ogImage.url,
   },
   openGraph: {
     type: 'website',
-    locale: 'ja_JP',
-    url: 'https://taxfree.dev',
-    siteName: 'tax_free',
-    title: 'tax_free',
-    description: 'Software Engineer & Researcher at Science Tokyo',
+    locale: siteConfig.locale,
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    title: siteConfig.name,
+    description: siteConfig.description,
     images: [
       {
-        url: '/icon.png',
-        width: 1706,
-        height: 1669,
-        alt: 'tax_free',
+        url: siteConfig.ogImage.url,
+        width: siteConfig.ogImage.width,
+        height: siteConfig.ogImage.height,
+        alt: siteConfig.name,
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    site: '@taxfree_python',
-    creator: '@taxfree_python',
-    title: 'tax_free',
-    description: 'Software Engineer & Researcher at Science Tokyo',
-    images: ['/icon.png'],
+    site: siteConfig.social.twitter,
+    creator: siteConfig.social.twitter,
+    title: siteConfig.name,
+    description: siteConfig.description,
+    images: [siteConfig.ogImage.url],
   },
 };
 

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,0 +1,21 @@
+/**
+ * Site-wide configuration
+ * This file centralizes all site metadata to avoid duplication across pages
+ */
+
+export const siteConfig = {
+  name: 'tax_free',
+  url: 'https://taxfree.dev',
+  description: 'Software Engineer & Researcher at Science Tokyo',
+  locale: 'ja_JP',
+  ogImage: {
+    url: '/icon.png',
+    width: 1706,
+    height: 1669,
+  },
+  social: {
+    twitter: '@taxfree_python',
+  },
+} as const;
+
+export type SiteConfig = typeof siteConfig;


### PR DESCRIPTION
## Summary

サイト設定（URL、Twitter handle、サイト名など）を`config/site.ts`で一元管理することで、保守性を向上させました。

Closes #22

## 変更内容

### 新規ファイル

**config/site.ts**
- サイトメタデータの集約管理
- TypeScriptの型安全性を活用
- すべてのページで共通して使用する設定を定義

```typescript
export const siteConfig = {
  name: 'tax_free',
  url: 'https://taxfree.dev',
  description: 'Software Engineer & Researcher at Science Tokyo',
  locale: 'ja_JP',
  ogImage: {
    url: '/icon.png',
    width: 1706,
    height: 1669,
  },
  social: {
    twitter: '@taxfree_python',
  },
} as const;
```

### 更新ファイル

以下のファイルでハードコードされた値を`siteConfig`からの参照に変更：
- `app/layout.tsx` - サイト全体のデフォルトメタデータ
- `app/blog/[slug]/page.tsx` - ブログ記事の動的メタデータ
- `app/blog/page.tsx` - ブログ一覧ページ
- `app/cv/page.tsx` - CVページ
- `app/gallery/page.tsx` - Galleryページ

## メリット

✅ **保守性向上**: 設定変更時の修正箇所が1箇所だけ  
✅ **整合性**: タイポや設定の不整合を防止  
✅ **可読性**: 設定の見通しが良くなる  
✅ **型安全性**: TypeScriptの型チェックが効く  
✅ **テスト容易性**: 設定をモックしやすくなる

## Before / After

### Before
```typescript
// 各ファイルでハードコード
url: 'https://taxfree.dev',
siteName: 'tax_free',
site: '@taxfree_python',
```

### After
```typescript
// config/site.tsから参照
url: siteConfig.url,
siteName: siteConfig.name,
site: siteConfig.social.twitter,
```

## Test plan

- [x] ビルドが成功することを確認
- [x] すべてのページで正しいメタデータが生成されることを確認
- [ ] デプロイ後、各ページのOGPメタデータが正しく表示されることを確認

## 関連

#5 (Twitter card実装) の改善提案として実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)