### PR TITLE
feat: CVページのactivities更新と日付表示形式の統一

### DIFF
--- a/app/cv/CVClient.tsx
+++ b/app/cv/CVClient.tsx
@@ -22,7 +22,7 @@ export default function CVClient({ activities, skills, certifications }: CVClien
 
   // Main experiences only: PFN, RIKEN, LayerX
   const mainExperiences = activities.filter(activity =>
-    ['pfn-education-project-engineer', 'riken-bdr-part-timer', 'layerx-summer-internship'].includes(activity.id)
+    ['pfn-education-project-engineer', 'riken-bdr-part-timer', 'layerx-ai-workforce-intern'].includes(activity.id)
   );
 
   return (

--- a/data/activities.yaml
+++ b/data/activities.yaml
@@ -1,5 +1,21 @@
 ---
 -
+  id: "layerx-ai-workforce-intern"
+  title: "LayerX Ai Workforce R&D インターン"
+  period:
+    start:
+      year: 2026
+      month: 1
+    end: null
+  description: "LayerXでapplied R&Dに従事"
+  skills:
+    - "Python"
+    - "LLM"
+    - "AI Agents"
+  category: "work"
+  detailedDescription: ""
+  achievements:
+-
   id: "riken-bdr-part-timer"
   title: "理化学研究所 BDR 研究パートタイマーⅠ"
   period:
@@ -87,7 +103,9 @@
     start:
       year: 2024
       month: 10
-    end: null
+    end:
+      year: 2025
+      month: 12
   description: "LLMを活用した教育向けサービスの企画・開発に従事。LLMだけに閉じないUI/UXも含めて、学習体験全体の設計に関わる"
   skills:
     - "Python"

--- a/lib/activityPeriod.ts
+++ b/lib/activityPeriod.ts
@@ -35,10 +35,6 @@ const assertActivityDateValid = (date: ActivityDate, context: string): void => {
   }
 };
 
-const isSameActivityDate = (a: ActivityDate, b: ActivityDate): boolean => {
-  return a.year === b.year && a.month === b.month && a.day === b.day;
-};
-
 export const validateActivityPeriod = (period: ActivityPeriod, context: string): void => {
   assertActivityDateValid(period.start, `${context}.period.start`);
 
@@ -84,15 +80,7 @@ export const formatActivityPeriod = (period: ActivityPeriod): string => {
     return `${start} - Present`;
   }
 
-  if (isSameActivityDate(period.start, period.end)) {
-    return start;
-  }
-
-  const shouldOmitYear =
-    period.start.year === period.end.year &&
-    (period.end.month !== undefined || period.end.day !== undefined);
-
-  const end = formatActivityDate(period.end, { omitYear: shouldOmitYear });
+  const end = formatActivityDate(period.end);
   return `${start} - ${end}`;
 };
 


### PR DESCRIPTION
## Summary
- LayerX Ai Workforce R&Dインターン（2026/01〜）を追加
- PFN教育プロジェクトエンジニアの終了日を2025/12に設定
- CVページのメイン表示を新しいLayerXインターンに変更
- 日付表示を常にYYYY/MM - YYYY/MM形式に統一（同月・同年の省略を廃止）

## Test plan
- [ ] CVページ（/cv）で新しいLayerXインターンが表示されることを確認
- [ ] PFNの終了日が2025/12と表示されることを確認
- [ ] 日付が`2025/10 - 2025/10`のように統一形式で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)