### PR TITLE
feat: ヒーローのサブタイトルを {AI, Agent} for {Science, Society} のタイプライター演出に変更

### DIFF
--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -9,6 +9,7 @@ interface DynamicSubtitleProps {
   holdMs?: number;
   deleteMs?: number;
   typeMs?: number;
+  wipePauseMs?: number;
 }
 
 function buildCycle(xLen: number, yLen: number): Array<[number, number]> {
@@ -28,6 +29,7 @@ export function DynamicSubtitle({
   holdMs = 1800,
   deleteMs = 60,
   typeMs = 80,
+  wipePauseMs = 450,
 }: DynamicSubtitleProps) {
   const { xOptions, yOptions, connector } = content;
   const initial = compose(xOptions[0] ?? '', connector, yOptions[0] ?? '');
@@ -70,6 +72,11 @@ export function DynamicSubtitle({
           await wait(deleteMs);
         }
 
+        if (keepPrefix.length === 0 && wipePauseMs > 0) {
+          await wait(wipePauseMs);
+          if (cancelled) return;
+        }
+
         while (current.length < target.length) {
           if (cancelled) return;
           current = target.slice(0, current.length + 1);
@@ -87,7 +94,7 @@ export function DynamicSubtitle({
       cancelled = true;
       if (timeoutId !== null) clearTimeout(timeoutId);
     };
-  }, [xOptions, yOptions, connector, holdMs, deleteMs, typeMs]);
+  }, [xOptions, yOptions, connector, holdMs, deleteMs, typeMs, wipePauseMs]);
 
   return (
     <Typography

--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -26,7 +26,7 @@ function compose(x: string, connector: string, y: string) {
 export function DynamicSubtitle({
   content,
   holdMs = 1800,
-  deleteMs = 47,
+  deleteMs = 60,
   typeMs = 80,
 }: DynamicSubtitleProps) {
   const { xOptions, yOptions, connector } = content;

--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -29,7 +29,7 @@ export function DynamicSubtitle({
   holdMs = 1800,
   deleteMs = 60,
   typeMs = 80,
-  wipePauseMs = 450,
+  wipePauseMs = 400,
 }: DynamicSubtitleProps) {
   const { xOptions, yOptions, connector } = content;
   const initial = compose(xOptions[0] ?? '', connector, yOptions[0] ?? '');

--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -4,13 +4,10 @@ import { useEffect, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import { HeroSubtitle } from '@/types/profile';
 
-interface DynamicSubtitleProps {
-  content: HeroSubtitle;
-  holdMs?: number;
-  deleteMs?: number;
-  typeMs?: number;
-  wipePauseMs?: number;
-}
+const HOLD_MS = 1800;
+const DELETE_MS = 60;
+const TYPE_MS = 80;
+const WIPE_PAUSE_MS = 400;
 
 function buildCycle(xLen: number, yLen: number): Array<[number, number]> {
   const cycle: Array<[number, number]> = [];
@@ -24,26 +21,16 @@ function compose(x: string, connector: string, y: string) {
   return `${x} ${connector} ${y}`;
 }
 
-export function DynamicSubtitle({
-  content,
-  holdMs = 1800,
-  deleteMs = 60,
-  typeMs = 80,
-  wipePauseMs = 400,
-}: DynamicSubtitleProps) {
+export function DynamicSubtitle({ content }: { content: HeroSubtitle }) {
   const { xOptions, yOptions, connector } = content;
-  const initial = compose(xOptions[0] ?? '', connector, yOptions[0] ?? '');
-  const [text, setText] = useState(initial);
+  const [text, setText] = useState(() => compose(xOptions[0], connector, yOptions[0]));
 
   useEffect(() => {
-    if (xOptions.length === 0 || yOptions.length === 0) return;
-
     const cycle = buildCycle(xOptions.length, yOptions.length);
     if (cycle.length <= 1) return;
 
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
     const wait = (ms: number) =>
       new Promise<void>((resolve) => {
         timeoutId = setTimeout(resolve, ms);
@@ -55,33 +42,32 @@ export function DynamicSubtitle({
       setText(current);
 
       while (!cancelled) {
-        await wait(holdMs);
+        await wait(HOLD_MS);
         if (cancelled) return;
 
         const next = (i + 1) % cycle.length;
         const [cxi] = cycle[i];
         const [nxi, nyi] = cycle[next];
         const target = compose(xOptions[nxi], connector, yOptions[nyi]);
-
         const keepPrefix = nxi === cxi ? `${xOptions[cxi]} ${connector} ` : '';
 
         while (current.length > keepPrefix.length) {
-          if (cancelled) return;
           current = current.slice(0, -1);
           setText(current);
-          await wait(deleteMs);
+          await wait(DELETE_MS);
+          if (cancelled) return;
         }
 
-        if (keepPrefix.length === 0 && wipePauseMs > 0) {
-          await wait(wipePauseMs);
+        if (keepPrefix.length === 0) {
+          await wait(WIPE_PAUSE_MS);
           if (cancelled) return;
         }
 
         while (current.length < target.length) {
-          if (cancelled) return;
           current = target.slice(0, current.length + 1);
           setText(current);
-          await wait(typeMs);
+          await wait(TYPE_MS);
+          if (cancelled) return;
         }
 
         i = next;
@@ -94,7 +80,7 @@ export function DynamicSubtitle({
       cancelled = true;
       if (timeoutId !== null) clearTimeout(timeoutId);
     };
-  }, [xOptions, yOptions, connector, holdMs, deleteMs, typeMs, wipePauseMs]);
+  }, [xOptions, yOptions, connector]);
 
   return (
     <Typography
@@ -109,7 +95,6 @@ export function DynamicSubtitle({
         fontFamily:
           '"JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace',
       }}
-      aria-label={`${xOptions.join(', ')} ${connector} ${yOptions.join(', ')}`}
     >
       <Box component="span" sx={{ whiteSpace: 'pre', color: 'text.primary' }}>
         {text}

--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import { HeroSubtitle } from '@/types/profile';
+
+interface DynamicSubtitleProps {
+  content: HeroSubtitle;
+  holdMs?: number;
+  deleteMs?: number;
+  typeMs?: number;
+}
+
+function buildCycle(xLen: number, yLen: number): Array<[number, number]> {
+  const cycle: Array<[number, number]> = [];
+  for (let i = 0; i < xLen; i++) {
+    for (let j = 0; j < yLen; j++) cycle.push([i, j]);
+  }
+  return cycle;
+}
+
+function compose(x: string, connector: string, y: string) {
+  return `${x} ${connector} ${y}`;
+}
+
+export function DynamicSubtitle({
+  content,
+  holdMs = 1800,
+  deleteMs = 47,
+  typeMs = 80,
+}: DynamicSubtitleProps) {
+  const { xOptions, yOptions, connector } = content;
+  const initial = compose(xOptions[0] ?? '', connector, yOptions[0] ?? '');
+  const [text, setText] = useState(initial);
+
+  useEffect(() => {
+    if (xOptions.length === 0 || yOptions.length === 0) return;
+
+    const cycle = buildCycle(xOptions.length, yOptions.length);
+    if (cycle.length <= 1) return;
+
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const wait = (ms: number) =>
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(resolve, ms);
+      });
+
+    const loop = async () => {
+      let i = 0;
+      let current = compose(xOptions[cycle[0][0]], connector, yOptions[cycle[0][1]]);
+      setText(current);
+
+      while (!cancelled) {
+        await wait(holdMs);
+        if (cancelled) return;
+
+        const next = (i + 1) % cycle.length;
+        const [cxi] = cycle[i];
+        const [nxi, nyi] = cycle[next];
+        const target = compose(xOptions[nxi], connector, yOptions[nyi]);
+
+        const keepPrefix = nxi === cxi ? `${xOptions[cxi]} ${connector} ` : '';
+
+        while (current.length > keepPrefix.length) {
+          if (cancelled) return;
+          current = current.slice(0, -1);
+          setText(current);
+          await wait(deleteMs);
+        }
+
+        while (current.length < target.length) {
+          if (cancelled) return;
+          current = target.slice(0, current.length + 1);
+          setText(current);
+          await wait(typeMs);
+        }
+
+        i = next;
+      }
+    };
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== null) clearTimeout(timeoutId);
+    };
+  }, [xOptions, yOptions, connector, holdMs, deleteMs, typeMs]);
+
+  return (
+    <Typography
+      variant="h5"
+      component="p"
+      sx={{
+        color: 'text.secondary',
+        mb: 3,
+        fontWeight: 500,
+        letterSpacing: '-0.01em',
+        minHeight: '1.6em',
+        fontFamily:
+          '"JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace',
+      }}
+      aria-label={`${xOptions.join(', ')} ${connector} ${yOptions.join(', ')}`}
+    >
+      <Box component="span" sx={{ whiteSpace: 'pre', color: 'text.primary' }}>
+        {text}
+      </Box>
+      <Box
+        component="span"
+        aria-hidden="true"
+        sx={{
+          display: 'inline-block',
+          width: '0.08em',
+          height: '1em',
+          ml: '0.08em',
+          verticalAlign: '-0.12em',
+          backgroundColor: 'currentColor',
+          animation: 'dynamic-subtitle-blink 1s steps(1, end) infinite',
+          '@keyframes dynamic-subtitle-blink': {
+            '0%, 50%': { opacity: 1 },
+            '50.01%, 100%': { opacity: 0 },
+          },
+        }}
+      />
+    </Typography>
+  );
+}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { Container, Typography } from '@mui/material';
 import { HeroContent } from '@/types/profile';
 import { SocialLinks } from './SocialLinks';
+import { DynamicSubtitle } from './DynamicSubtitle';
 
 interface HeroSectionProps {
   content: HeroContent;
@@ -12,13 +13,7 @@ export function HeroSection({ content }: HeroSectionProps) {
       <Typography variant="h1" component="h1" gutterBottom sx={{ fontSize: { xs: '2rem', md: '2.5rem' }, mb: 3 }}>
         {content.title}
       </Typography>
-      <Typography
-        variant="h5"
-        component="p"
-        sx={{ color: 'text.secondary', mb: 3, fontWeight: 400, letterSpacing: '-0.01em' }}
-      >
-        {content.subtitle}
-      </Typography>
+      <DynamicSubtitle content={content.subtitle} />
       <SocialLinks links={content.socialLinks} />
     </Container>
   );

--- a/data/profile.ts
+++ b/data/profile.ts
@@ -2,7 +2,11 @@ import { HeroContent, CertificationsContent } from '@/types/profile';
 
 export const heroContent: HeroContent = {
   title: 'tax_free',
-  subtitle: '最適化とAI Agentで格差を是正する',
+  subtitle: {
+    xOptions: ['AI', 'Agent'],
+    yOptions: ['Science', 'Society'],
+    connector: 'for',
+  },
   socialLinks: [
     {
       label: 'GitHub',

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -7,8 +7,8 @@ export interface SocialLink {
 }
 
 export interface HeroSubtitle {
-  xOptions: string[];
-  yOptions: string[];
+  xOptions: readonly [string, ...string[]];
+  yOptions: readonly [string, ...string[]];
   connector: string;
 }
 

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -6,9 +6,15 @@ export interface SocialLink {
   color?: 'primary' | 'secondary' | 'inherit';
 }
 
+export interface HeroSubtitle {
+  xOptions: string[];
+  yOptions: string[];
+  connector: string;
+}
+
 export interface HeroContent {
   title: string;
-  subtitle: string;
+  subtitle: HeroSubtitle;
   socialLinks: SocialLink[];
 }
 


### PR DESCRIPTION
## Summary
- 先頭ページのサブタイトルを「最適化とAI Agentで格差を是正する」から「{AI, Agent} for {Science, Society}」のタイプライター演出に変更
- 表示は単一文字列 `${X} ${connector} ${Y}` を1文字単位で削除/タイプ、カーソルは常に末尾でブリンク
- 巡回順は lexicographic: `AI for Science → AI for Society → Agent for Science → Agent for Society → (cycle)`
- Y のみ変化する遷移は `X for ` を残して末尾だけ書き換え、X が変わる遷移は全消し → 400ms ポーズ → 頭から再タイプ

## 設計方針
- `DynamicSubtitle` の props は `content: HeroSubtitle` のみ。タイミングは module-level const で固定 (`HOLD_MS / DELETE_MS / TYPE_MS / WIPE_PAUSE_MS`)
- `HeroSubtitle.xOptions / yOptions` は `readonly [string, ...string[]]` の非空タプルで型的に保証

## 変更ファイル
- `types/profile.ts` — `HeroSubtitle` 型を新設、非空タプルで縛る
- `data/profile.ts` — `{AI, Agent} × {Science, Society}`, connector: `for`
- `components/DynamicSubtitle.tsx` — 新規クライアントコンポーネント
- `components/HeroSection.tsx` — `DynamicSubtitle` を埋め込み

## Test plan
- [ ] `npm run dev` でローカル起動し、トップで巡回・カーソル位置・タイミングが意図通りか目視確認
- [ ] X 変化遷移で全消し → 400ms ポーズ → 再タイプになっているか
- [ ] Y のみ遷移で `X for ` が残ったまま末尾だけ書き換わるか
- [ ] カーソルが行の途中に出ないこと
- [ ] `npm run build` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)