### PR TITLE
feat: ホーム画面で左上のブランド表記を非表示

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { AppBar, Toolbar, Container, Typography, Box } from '@mui/material';
 
 const navLinks = [
@@ -9,6 +12,9 @@ const navLinks = [
 ];
 
 export function Header() {
+  const pathname = usePathname();
+  const isHome = pathname === '/';
+
   return (
     <AppBar
       position="sticky"
@@ -19,23 +25,30 @@ export function Header() {
       elevation={0}
     >
       <Container maxWidth="md">
-        <Toolbar sx={{ justifyContent: 'space-between', gap: 2 }}>
-          <Link href="/" style={{ textDecoration: 'none' }}>
-            <Typography
-              variant="h5"
-              component="div"
-              fontWeight="bold"
-              sx={{
-                color: 'text.primary',
-                '&:hover': {
-                  color: 'primary.main',
-                },
-                transition: 'color 0.2s',
-              }}
-            >
-              tax_free
-            </Typography>
-          </Link>
+        <Toolbar
+          sx={{
+            justifyContent: isHome ? 'flex-end' : 'space-between',
+            gap: 2,
+          }}
+        >
+          {!isHome && (
+            <Link href="/" style={{ textDecoration: 'none' }}>
+              <Typography
+                variant="h5"
+                component="div"
+                fontWeight="bold"
+                sx={{
+                  color: 'text.primary',
+                  '&:hover': {
+                    color: 'primary.main',
+                  },
+                  transition: 'color 0.2s',
+                }}
+              >
+                tax_free
+              </Typography>
+            </Link>
+          )}
 
           <Box sx={{ display: 'flex', gap: { xs: 2, sm: 3 } }}>
             {navLinks.map((link) => (


### PR DESCRIPTION
## Summary
- / でヒーローの大きな \`tax_free\` と左上ロゴが二重になっていたのを解消
- \`/\` では左上の \`tax_free\` を非表示、ナビ (Blog / CV) を右寄せ
- \`/blog\` \`/cv\` などサブページでは従来通りロゴ + ナビを表示(ナビ起点として残す)

## 実装
- \`Header\` を \`'use client'\` 化し、\`usePathname()\` で \`/\` を判定
- ホーム時は \`Toolbar\` の \`justify-content\` を \`flex-end\` に切替

## 変更ファイル
- \`components/Header.tsx\`

## Test plan
- [ ] \`npm run dev\` で / を開きヒーロー以外に \`tax_free\` 表記が無いことを確認
- [ ] /blog /cv で左上にロゴが出ること
- [ ] サブページでロゴ → / クリックでホームに戻れること
- [ ] スティッキー時の透過/blur が崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)