### PR TITLE
feat: CV の期間表記を 3 カラム grid で揃える

### DIFF
--- a/components/ActivitiesSection.tsx
+++ b/components/ActivitiesSection.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Container, Typography, Box, Stack, Button, Collapse } from '@mui/material';
 import { ProjectActivity, ActivityCategory } from '@/types/activities';
-import { formatActivityPeriod, getActivityPeriodEndValue, getActivityPeriodStartValue } from '@/lib/activityPeriod';
+import { formatActivityPeriodParts, getActivityPeriodEndValue, getActivityPeriodStartValue } from '@/lib/activityPeriod';
 
 interface ActivitiesSectionProps {
   activities: ProjectActivity[];
@@ -118,16 +118,31 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
                       >
                         {activity.title}
                       </Typography>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
+                      <Box
                         sx={{
                           ml: 2,
-                          whiteSpace: 'nowrap'
+                          display: 'inline-grid',
+                          gridTemplateColumns: 'auto auto auto',
+                          columnGap: '0.4em',
+                          alignItems: 'baseline',
+                          fontVariantNumeric: 'tabular-nums',
+                          whiteSpace: 'nowrap',
+                          color: 'text.secondary',
+                          fontSize: (theme) => theme.typography.body2.fontSize,
+                          lineHeight: (theme) => theme.typography.body2.lineHeight,
                         }}
                       >
-                        {formatActivityPeriod(activity.period)}
-                      </Typography>
+                        {(() => {
+                          const { start, end } = formatActivityPeriodParts(activity.period);
+                          return (
+                            <>
+                              <Box component="span" sx={{ textAlign: 'right' }}>{start}</Box>
+                              <Box component="span">-</Box>
+                              <Box component="span" sx={{ textAlign: 'right', minWidth: '4.5em' }}>{end}</Box>
+                            </>
+                          );
+                        })()}
+                      </Box>
                     </Box>
                     <Collapse in={expandedIds.has(activity.id)}>
                       <Box sx={{ py: 2, pl: 2 }}>

--- a/components/ActivitiesSection.tsx
+++ b/components/ActivitiesSection.tsx
@@ -138,7 +138,7 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
                             <>
                               <Box component="span" sx={{ textAlign: 'right' }}>{start}</Box>
                               <Box component="span">-</Box>
-                              <Box component="span" sx={{ textAlign: 'right', minWidth: '4.5em' }}>{end}</Box>
+                              <Box component="span" sx={{ textAlign: 'right', minWidth: '4em' }}>{end}</Box>
                             </>
                           );
                         })()}

--- a/lib/activityPeriod.ts
+++ b/lib/activityPeriod.ts
@@ -73,15 +73,18 @@ export const formatActivityDate = (date: ActivityDate, options?: { omitYear?: bo
   return parts.join('/');
 };
 
-export const formatActivityPeriod = (period: ActivityPeriod): string => {
+export interface FormattedPeriodParts {
+  start: string;
+  end: string;
+}
+
+export const formatActivityPeriodParts = (period: ActivityPeriod): FormattedPeriodParts => {
   const start = formatActivityDate(period.start);
-
-  if (period.end === undefined || period.end === null) {
-    return `${start} - Present`;
-  }
-
-  const end = formatActivityDate(period.end);
-  return `${start} - ${end}`;
+  const end =
+    period.end === undefined || period.end === null
+      ? 'Present'
+      : formatActivityDate(period.end);
+  return { start, end };
 };
 
 export const getActivityPeriodEndValue = (period: ActivityPeriod): number => {


### PR DESCRIPTION
## Summary
CV (\`/cv\`) の Experience セクションで \`<start_date> - <end_date>\` のハイフン位置が proportional フォントの桁幅差でドリフトしていた問題を解消。

- 例: \`2025/09 - Present\` と \`2024/10 - 2025/12\` で \`-\` の x 座標がずれていた
- 原因: 数字 (1 vs 0/9 等) の幅差 + 右端の \`Present\` と \`YYYY/MM\` の幅差

## アプローチ
\`<start> - <end>\` を単一文字列でなく **3カラム inline-grid** でレンダリング:

\`\`\`
[ start ] [ - ] [ end ]
   右寄せ   固定   右寄せ
\`\`\`

- \`font-variant-numeric: tabular-nums\` で \`YYYY/MM\` の桁幅を一定化 → col1 幅が全行で同じ
- col3 (\`Present\` or \`YYYY/MM\`) に \`min-width: 4.5em\` を入れて Present 行と日付行で col3 幅を共通化 → \`-\` の x 座標が全行で揃う

## 変更ファイル
- \`lib/activityPeriod.ts\` — \`formatActivityPeriod\` を \`formatActivityPeriodParts\` に置換 (start/end の構造化を返す)
- \`components/ActivitiesSection.tsx\` — Period 表示を Typography 単一テキストから Box (inline-grid 3 カラム) に変更

## Test plan
- [ ] \`npm run dev\` で \`/cv\` を開き、Experience セクションの全行で \`-\` の縦ラインが揃うことを確認
- [ ] Present 行 (\`2026/01 - Present\` 等) と日付行 (\`2024/10 - 2025/12\` 等) の右端も揃うこと
- [ ] 既存のホバー / クリック展開挙動が崩れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)