### PR TITLE
feat: SNS リンクをテキストリンク化、Header と語彙統一

### DIFF
--- a/components/SocialLinks.tsx
+++ b/components/SocialLinks.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Box, Button } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { SocialLink } from '@/types/profile';
 
 interface SocialLinksProps {
@@ -8,26 +8,29 @@ interface SocialLinksProps {
 
 export function SocialLinks({ links }: SocialLinksProps) {
   return (
-    <Box display="flex" gap={2} justifyContent="center" flexWrap="wrap">
+    <Box display="flex" gap={3} justifyContent="center" flexWrap="wrap">
       {links.map((link) => (
-        <Button
+        <Link
           key={link.href}
-          component={Link}
           href={link.href}
           target="_blank"
           rel="noopener noreferrer"
-          variant="contained"
-          color={link.color ?? 'primary'}
-          sx={{
-            boxShadow: 'none',
-            '&:hover': {
-              opacity: 0.9,
-              boxShadow: 'none',
-            },
-          }}
+          style={{ textDecoration: 'none' }}
         >
-          {link.label}
-        </Button>
+          <Typography
+            variant="body1"
+            sx={{
+              color: 'text.secondary',
+              '&:hover': {
+                color: 'primary.main',
+              },
+              transition: 'color 0.2s',
+              fontWeight: 500,
+            }}
+          >
+            {link.label}
+          </Typography>
+        </Link>
       ))}
     </Box>
   );

--- a/data/profile.ts
+++ b/data/profile.ts
@@ -11,17 +11,14 @@ export const heroContent: HeroContent = {
     {
       label: 'GitHub',
       href: 'https://github.com/taxfree-python',
-      color: 'primary',
     },
     {
       label: 'Twitter',
       href: 'https://twitter.com/taxfree_python',
-      color: 'primary',
     },
     {
       label: 'LinkedIn',
       href: 'https://www.linkedin.com/in/yu-chinen',
-      color: 'primary',
     },
   ],
 };

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -3,7 +3,6 @@ import { ActivityDate } from './activities';
 export interface SocialLink {
   label: string;
   href: string;
-  color?: 'primary' | 'secondary' | 'inherit';
 }
 
 export interface HeroSubtitle {


### PR DESCRIPTION
## Summary
\`/\` のヒーロー下の GitHub / Twitter / LinkedIn が \`variant=contained\` の filled ボタンで、
モノトーンの全体デザインから浮いて見えていたのを解消。

## アプローチ
Header の Blog / CV ナビと完全に同じ語彙に統一:

- \`Button\` (filled) → \`Link\` + \`Typography\` (テキストのみ)
- color: \`text.secondary\` → hover で \`primary.main\`
- \`transition: color 0.2s\`, \`fontWeight: 500\`

## 変更ファイル
- \`components/SocialLinks.tsx\` — \`Button\` を撤去、Header と同じ \`Link\` + \`Typography\` パターンに
- \`types/profile.ts\` — 未使用になった \`SocialLink.color\` を削除
- \`data/profile.ts\` — 各リンクの \`color: 'primary'\` を削除

## Test plan
- [ ] \`npm run dev\` で \`/\` を開き、GitHub / Twitter / LinkedIn がテキストとして表示されること
- [ ] hover で文字色が \`primary.main\` に滑らかに変わること
- [ ] クリックで該当 URL に新タブで遷移すること
- [ ] Header の Blog / CV と書体・色味が揃って見えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)