### PR TITLE
feat: タイプアニメの部分消し時の間を調整

### DIFF
--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -6,8 +6,10 @@ import { HeroSubtitle } from '@/types/profile';
 
 const HOLD_MS = 1800;
 const DELETE_MS = 60;
+const SWAP_DELETE_MS = 85;
 const TYPE_MS = 80;
 const WIPE_PAUSE_MS = 400;
+const SWAP_PAUSE_MS = 200;
 
 function buildCycle(xLen: number, yLen: number): Array<[number, number]> {
   const cycle: Array<[number, number]> = [];
@@ -51,17 +53,16 @@ export function DynamicSubtitle({ content }: { content: HeroSubtitle }) {
         const target = compose(xOptions[nxi], connector, yOptions[nyi]);
         const keepPrefix = nxi === cxi ? `${xOptions[cxi]} ${connector} ` : '';
 
+        const deleteMs = keepPrefix.length === 0 ? DELETE_MS : SWAP_DELETE_MS;
         while (current.length > keepPrefix.length) {
           current = current.slice(0, -1);
           setText(current);
-          await wait(DELETE_MS);
+          await wait(deleteMs);
           if (cancelled) return;
         }
 
-        if (keepPrefix.length === 0) {
-          await wait(WIPE_PAUSE_MS);
-          if (cancelled) return;
-        }
+        await wait(keepPrefix.length === 0 ? WIPE_PAUSE_MS : SWAP_PAUSE_MS);
+        if (cancelled) return;
 
         while (current.length < target.length) {
           current = target.slice(0, current.length + 1);


### PR DESCRIPTION
## 概要
トップページの DynamicSubtitle(「AI for Science」→「AI for Society」のように切り替わるタイプアニメ)で、**for の後だけが変わる「部分消し」のとき**に間が短く急に切り替わって見えたため、ポーズと削除速度を調整した。

## 変更点
- 部分消しの消し終わりにポーズを追加(従来は全消しのみ)
  - `SWAP_PAUSE_MS = 200`(全消しは `WIPE_PAUSE_MS = 400` のまま)
- 部分消しの削除速度をやや遅く
  - `SWAP_DELETE_MS = 85`(全消しは `DELETE_MS = 60` のまま)

## 現在のパラメータ
| | 消す | 書く |
|---|---|---|
| 部分(for の後だけ) | 85ms | 80ms |
| 全部(for の前も) | 60ms | 80ms |

書く速度(`TYPE_MS = 80`)は部分・全部共通で変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)