### PR TITLE
fix: Language(CV)の数字にtabular-numsを適用して桁位置を揃える

### DIFF
--- a/components/CertificationsSection.tsx
+++ b/components/CertificationsSection.tsx
@@ -70,7 +70,8 @@ export function CertificationsSection({ content }: CertificationsSectionProps) {
                 color="text.secondary"
                 sx={{
                   ml: 2,
-                  whiteSpace: 'nowrap'
+                  whiteSpace: 'nowrap',
+                  fontVariantNumeric: 'tabular-nums'
                 }}
               >
                 {formatActivityDate(certification.acquiredDate)}
@@ -90,7 +91,8 @@ export function CertificationsSection({ content }: CertificationsSectionProps) {
                     variant="body1"
                     sx={{
                       fontWeight: 500,
-                      mb: 0.5
+                      mb: 0.5,
+                      fontVariantNumeric: 'tabular-nums'
                     }}
                   >
                     {certification.score}
@@ -102,7 +104,8 @@ export function CertificationsSection({ content }: CertificationsSectionProps) {
                     color="text.secondary"
                     sx={{
                       lineHeight: 1.7,
-                      letterSpacing: '-0.01em'
+                      letterSpacing: '-0.01em',
+                      fontVariantNumeric: 'tabular-nums'
                     }}
                   >
                     {certification.description}


### PR DESCRIPTION
## 概要

CVの **Experience** セクションでは日付に `fontVariantNumeric: 'tabular-nums'` を適用し、文字（桁数）によらず位置が揃うようにしていましたが、**Language（Certifications）** セクションの数字には適用されていませんでした。

そのため、`2025/03` と `2021/10` のようにプロポーショナル数字だと桁幅が揃わず、位置がわずかにずれていました。

## 変更内容

`components/CertificationsSection.tsx` の以下に `fontVariantNumeric: 'tabular-nums'` を追加:

- 取得日（`acquiredDate`）の表示
- スコア（TOEIC / CSEスコアなど）の表示
- 説明文（数字を含む）の表示

## 確認

- `npm run lint` ✅
- `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)