### PR TITLE
feat: CVにPublications & Presentationsセクションを追加

### DIFF
--- a/app/cv/CVClient.tsx
+++ b/app/cv/CVClient.tsx
@@ -3,14 +3,17 @@
 import { Container, Box } from '@mui/material';
 import { SkillsSection } from '@/components/SkillsSection';
 import { ActivitiesSection } from '@/components/ActivitiesSection';
+import { PublicationsSection } from '@/components/PublicationsSection';
 import { CertificationsSection } from '@/components/CertificationsSection';
 import type { CertificationsContent } from '@/types/profile';
 import type { ProjectActivity } from '@/types/activities';
+import type { Publication } from '@/types/publications';
 import type { SkillDetail } from '@/types/skills';
 
 type CVClientProps = {
   activities: ProjectActivity[];
   skills: SkillDetail[];
+  publications: Publication[];
   certifications: CertificationsContent;
 };
 
@@ -24,13 +27,15 @@ const mainExperienceIds: ReadonlySet<string> = new Set([
   'pfn-education-project-engineer',
   'riken-bdr-part-timer',
   'layerx-ai-workforce-intern',
+  'autonomous-lab-scheduling',
+  'doctor-car-data-analysis',
 ]);
 
-export default function CVClient({ activities, skills, certifications }: CVClientProps) {
+export default function CVClient({ activities, skills, publications, certifications }: CVClientProps) {
   // Core skills only: Python, React/TypeScript, AI Agents
   const coreSkills = skills.filter((skill) => coreSkillNames.has(skill.name));
 
-  // Main experiences only: PFN, RIKEN, LayerX
+  // Main experiences: PFN, RIKEN, LayerX + all research projects
   const mainExperiences = activities.filter((activity) => mainExperienceIds.has(activity.id));
 
   return (
@@ -49,6 +54,7 @@ export default function CVClient({ activities, skills, certifications }: CVClien
             activities={mainExperiences}
             allActivities={activities}
           />
+          <PublicationsSection publications={publications} />
           <CertificationsSection content={certifications} />
         </Box>
       </Container>

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from 'next';
 import { getProjectsAndActivities } from '@/lib/activities';
 import { getSkillsData } from '@/lib/skills';
+import { getPublications } from '@/lib/publications';
 import { certificationsContent } from '@/data/profile';
 import { siteConfig } from '@/config/site';
 import CVClient from './CVClient';
 
-const cvDescription = 'Curriculum Vitae - Skills, Experience, and Certifications';
+const cvDescription = 'Curriculum Vitae - Skills, Experience, Publications, and Certifications';
 
 export const metadata: Metadata = {
   title: `CV - ${siteConfig.name}`,
@@ -39,11 +40,13 @@ export const metadata: Metadata = {
 export default function CVPage() {
   const activities = getProjectsAndActivities();
   const { skills } = getSkillsData();
+  const publications = getPublications();
 
   return (
     <CVClient
       activities={activities}
       skills={skills}
+      publications={publications}
       certifications={certificationsContent}
     />
   );

--- a/components/ActivitiesSection.tsx
+++ b/components/ActivitiesSection.tsx
@@ -63,7 +63,7 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
   }
 
   return (
-    <Container maxWidth="md" component="section" sx={{ py: 6, pb: 10 }}>
+    <Container maxWidth="md" component="section" sx={{ pt: 6, pb: 3 }}>
       <Typography
         variant="h4"
         component="h2"
@@ -173,7 +173,7 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
       </Stack>
 
       {hasMore && (
-        <Box sx={{ mt: 6, textAlign: 'center' }}>
+        <Box sx={{ mt: 3, textAlign: 'center' }}>
           <Button
             onClick={() => setShowAll((currentShowAll) => !currentShowAll)}
             sx={{

--- a/components/PublicationsSection.tsx
+++ b/components/PublicationsSection.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Container, Typography, Box, Stack, Link } from '@mui/material';
+import type { Publication, PublicationType } from '@/types/publications';
+import { activityDateToComparableValue, formatActivityDate } from '@/lib/activityPeriod';
+
+type PublicationsSectionProps = {
+  publications: Publication[];
+};
+
+const typeLabels: Record<PublicationType, string> = {
+  oral: 'Oral',
+  poster: 'Poster',
+  talk: 'Talk',
+};
+
+const highlightedAuthors: ReadonlySet<string> = new Set(['Yu Chinen', '知念優', '知念 優']);
+
+export function PublicationsSection({ publications }: PublicationsSectionProps) {
+  // Sort publications by date (most recent first)
+  const sortedPublications = [...publications].sort(
+    (a, b) => activityDateToComparableValue(b.date) - activityDateToComparableValue(a.date),
+  );
+
+  if (sortedPublications.length === 0) return null;
+
+  return (
+    <Container maxWidth="md" component="section" sx={{ py: 6 }}>
+      <Typography
+        variant="h4"
+        component="h2"
+        gutterBottom
+        sx={{
+          mb: 4,
+          fontWeight: 400,
+          letterSpacing: '-0.02em'
+        }}
+      >
+        Publications & Presentations
+      </Typography>
+      <Stack spacing={2}>
+        {sortedPublications.map((publication) => (
+          <Box
+            key={publication.id}
+            sx={{
+              py: 1,
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+              }}
+            >
+              <Typography
+                variant="body1"
+                sx={{
+                  fontWeight: 500,
+                  letterSpacing: '-0.01em'
+                }}
+              >
+                {publication.title}
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{
+                  ml: 2,
+                  whiteSpace: 'nowrap',
+                  fontVariantNumeric: 'tabular-nums'
+                }}
+              >
+                {formatActivityDate(publication.date)}
+              </Typography>
+            </Box>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 0.5, letterSpacing: '-0.01em' }}
+            >
+              {publication.authors.map((author, index) => (
+                <Box component="span" key={author}>
+                  {index > 0 && ', '}
+                  <Box
+                    component="span"
+                    sx={highlightedAuthors.has(author) ? { color: 'text.primary', fontWeight: 500 } : {}}
+                  >
+                    {author}
+                  </Box>
+                </Box>
+              ))}
+            </Typography>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 0.25, letterSpacing: '-0.01em' }}
+            >
+              {publication.venue} ({typeLabels[publication.type]})
+              {publication.links?.map((link) => (
+                <Box component="span" key={link.url}>
+                  {' · '}
+                  <Link
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    color="inherit"
+                    underline="hover"
+                  >
+                    {link.label}
+                  </Link>
+                </Box>
+              ))}
+            </Typography>
+          </Box>
+        ))}
+      </Stack>
+    </Container>
+  );
+}

--- a/data/publications.yaml
+++ b/data/publications.yaml
@@ -1,0 +1,84 @@
+---
+-
+  id: "jsai2026-collaborative-idea-evolution"
+  title: "multi-agentシステムによるラボ固有知識と文献に基づく共同研究アイディアの進化的生成"
+  authors:
+    - "知念優"
+    - "尾崎遼"
+  venue: "2026年度 人工知能学会全国大会 (JSAI2026), OS-30 進化するAIサイエンティスト"
+  type: "oral"
+  date:
+    year: 2026
+    month: 6
+  links:
+    -
+      label: "Confit"
+      url: "https://pub.confit.atlas.jp/ja/event/jsai2026/presentation/5L1-OS-30-03"
+-
+  id: "icml2026-ai4science-ideation-diversity"
+  title: "On the Effects of Reasoning Effort and Prompt-Based Diversification on Scientific Ideation Diversity"
+  authors:
+    - "Yu Chinen"
+    - "Haruka Ozaki"
+  venue: "ICML 2026 AI4Science Workshop"
+  type: "poster"
+  date:
+    year: 2026
+    month: 7
+  links:
+    -
+      label: "OpenReview"
+      url: "https://openreview.net/forum?id=xt5P634aET"
+-
+  id: "jaam53-doctor-car-dispatch-criteria"
+  title: "当院ドクターカー病院前救急医療体制における出動要請基準に関する検討"
+  authors:
+    - "岩﨑陽平"
+    - "知念優"
+    - "山下真"
+    - "北原嶺"
+    - "原島瑞葵"
+    - "服部恭平"
+    - "森周介"
+    - "小林和博"
+    - "中田和秀"
+    - "森下幸治"
+  venue: "第53回日本救急医学会総会・学術集会 (主題関連セッション21, O21-3)"
+  type: "oral"
+  date:
+    year: 2025
+    month: 10
+-
+  id: "jsicm52-doctor-car-optimization"
+  title: "ドクターカー運用の最適化を追求する～AI解析への布石"
+  authors:
+    - "森周介"
+    - "山下真"
+    - "中田和秀"
+    - "小林和博"
+    - "岩崎陽平"
+    - "北原嶺"
+    - "原島瑞葵"
+    - "服部恭平"
+    - "知念優"
+    - "森下幸治"
+  venue: "第52回日本集中治療医学会学術集会 (ポスター102 AI, P102-6)"
+  type: "poster"
+  date:
+    year: 2025
+    month: 3
+-
+  id: "ai4x-2026-evolving-collaborative-research-ideas"
+  title: "Evolving Collaborative Research Ideas with Multi-Agent Grounding in Lab-Specific Contexts and Literature"
+  authors:
+    - "Yu Chinen"
+    - "Haruka Ozaki"
+  venue: "AI4X – Accelerate Conference 2026"
+  type: "oral"
+  date:
+    year: 2026
+    month: 6
+  links:
+    -
+      label: "OpenReview"
+      url: "https://openreview.net/forum?id=RDTccqN78N"

--- a/lib/publications.ts
+++ b/lib/publications.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { cache } from 'react';
+import YAML from 'yaml';
+
+import type { Publication, PublicationLink, PublicationType } from '@/types/publications';
+import { assert } from '@/lib/assert';
+import { ensureObject, toString, toStringArray } from '@/lib/validation';
+import { validateActivityDate } from '@/lib/activityPeriod';
+
+const publicationsFilePath = path.join(process.cwd(), 'data', 'publications.yaml');
+
+const publicationTypeValues = ['oral', 'poster', 'talk'] as const satisfies readonly PublicationType[];
+const publicationTypeSet: ReadonlySet<string> = new Set(publicationTypeValues);
+
+const isPublicationType = (value: string): value is PublicationType =>
+  publicationTypeSet.has(value);
+
+const validatePublicationLink = (raw: unknown, context: string): PublicationLink => {
+  const obj = ensureObject(raw, context);
+  return {
+    label: toString(obj.label, `${context}.label`),
+    url: toString(obj.url, `${context}.url`),
+  };
+};
+
+export const validatePublication = (raw: unknown): Publication => {
+  const obj = ensureObject(raw, 'Publication');
+  const id = toString(obj.id, 'Publication.id');
+  const context = `Publication(${id})`;
+  const title = toString(obj.title, `${context}.title`);
+  const authors = toStringArray(obj.authors, `${context}.authors`);
+  const venue = toString(obj.venue, `${context}.venue`);
+  const typeValue = toString(obj.type, `${context}.type`);
+  const date = validateActivityDate(obj.date, `${context}.date`);
+
+  assert(
+    isPublicationType(typeValue),
+    `${context}.type must be one of: ${publicationTypeValues.join(', ')}`,
+  );
+  assert(authors.length > 0, `${context}.authors must not be empty`);
+
+  const publication: Publication = {
+    id,
+    title,
+    authors,
+    venue,
+    type: typeValue,
+    date,
+  };
+
+  if (obj.links !== undefined && obj.links !== null) {
+    assert(Array.isArray(obj.links), `${context}.links must be an array`);
+    publication.links = obj.links.map((item, index) =>
+      validatePublicationLink(item, `${context}.links[${index}]`),
+    );
+  }
+
+  return publication;
+};
+
+function readPublicationsFile(): Publication[] {
+  const fileContents = fs.readFileSync(publicationsFilePath, 'utf-8');
+  const parsed = YAML.parse(fileContents);
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('Publications data must be an array of publications');
+  }
+
+  return parsed.map((item, index) => {
+    try {
+      return validatePublication(item);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown validation error';
+      throw new Error(`Invalid publication at index ${index}: ${message}`);
+    }
+  });
+}
+
+export const getPublications = cache((): Publication[] => {
+  return readPublicationsFile();
+});

--- a/types/publications.ts
+++ b/types/publications.ts
@@ -1,0 +1,18 @@
+import type { ActivityDate } from './activities';
+
+export type PublicationType = 'oral' | 'poster' | 'talk';
+
+export type PublicationLink = {
+  label: string;
+  url: string;
+};
+
+export type Publication = {
+  id: string;
+  title: string;
+  authors: string[];
+  venue: string;
+  type: PublicationType;
+  date: ActivityDate;
+  links?: PublicationLink[];
+};


### PR DESCRIPTION
## 概要
研究成果(論文・学会発表)が増えてきたため、Experienceに混ぜずにCVへ専用の「Publications & Presentations」セクションを新設しました。あわせてResearchプロジェクトをshow moreなしで見えるようにしています。

## 変更内容
### Publications & Presentations セクション新設
- `data/publications.yaml`: 論文・発表データ(タイトル、著者順、venue、形式、日付、リンク)
- `types/publications.ts` / `lib/publications.ts`: 既存のactivitiesと同じ流儀の型・YAMLローダー・バリデーション
- `components/PublicationsSection.tsx`: 新しい順のコンパクトな一覧。著者リスト中の本人名 (Yu Chinen / 知念優) を強調表示

### 登録した発表 (5件)
| タイトル | venue | 形式 |
|---|---|---|
| On the Effects of Reasoning Effort and Prompt-Based Diversification on Scientific Ideation Diversity | ICML 2026 AI4Science Workshop | Poster |
| multi-agentシステムによるラボ固有知識と文献に基づく共同研究アイディアの進化的生成 | JSAI2026 OS-30 | Oral |
| Evolving Collaborative Research Ideas with Multi-Agent Grounding in Lab-Specific Contexts and Literature | AI4X – Accelerate Conference 2026 | Oral |
| 当院ドクターカー病院前救急医療体制における出動要請基準に関する検討 | 第53回日本救急医学会総会・学術集会 | Oral |
| ドクターカー運用の最適化を追求する～AI解析への布石 | 第52回日本集中治療医学会学術集会 | Poster |

### Experience の改善
- Researchカテゴリ2件(一杉研共同研究・ドクターカーデータ分析)をデフォルト表示に追加
- Experience下部の余白(`pb: 10`)とshow moreボタンの余白を縮小し、セクション間のリズムを統一

## 確認
- `npm run check` (lint / typecheck / vitest) 通過
- `npm run build` 成功、生成されたcv.htmlに全エントリの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)