### PR TITLE
Restyle hero social links as lowercase mono text

### DIFF
--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -120,8 +120,7 @@ export function DynamicSubtitle({ content }: DynamicSubtitleProps) {
         fontWeight: 500,
         letterSpacing: '-0.01em',
         minHeight: '1.6em',
-        fontFamily:
-          '"JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace',
+        fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
       }}
     >
       <Box component="span" sx={{ whiteSpace: 'pre', color: 'text.primary' }}>

--- a/components/SocialLinks.tsx
+++ b/components/SocialLinks.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import Link from 'next/link';
 import { Box, Typography } from '@mui/material';
 import type { LabeledLink } from '@/types';
@@ -8,29 +9,43 @@ type SocialLinksProps = {
 
 export function SocialLinks({ links }: SocialLinksProps) {
   return (
-    <Box display="flex" gap={3} justifyContent="center" flexWrap="wrap">
-      {links.map((link) => (
-        <Link
-          key={link.url}
-          href={link.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ textDecoration: 'none' }}
-        >
-          <Typography
-            variant="body1"
-            sx={{
-              color: 'text.secondary',
-              '&:hover': {
-                color: 'primary.main',
-              },
-              transition: 'color 0.2s',
-              fontWeight: 500,
-            }}
-          >
-            {link.label}
-          </Typography>
-        </Link>
+    <Box
+      display="flex"
+      gap={2}
+      justifyContent="center"
+      alignItems="center"
+      flexWrap="wrap"
+      sx={{
+        fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+      }}
+    >
+      {links.map((link, index) => (
+        <Fragment key={link.url}>
+          {index > 0 && (
+            <Typography component="span" aria-hidden="true" sx={{ color: 'grey.700', fontFamily: 'inherit' }}>
+              ·
+            </Typography>
+          )}
+          <Link href={link.url} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>
+            <Typography
+              variant="body2"
+              component="span"
+              sx={{
+                color: 'grey.500',
+                fontFamily: 'inherit',
+                textTransform: 'lowercase',
+                transition: 'color 0.2s',
+                '&:hover': {
+                  color: 'text.primary',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: '0.3em',
+                },
+              }}
+            >
+              {link.label}
+            </Typography>
+          </Link>
+        </Fragment>
       ))}
     </Box>
   );


### PR DESCRIPTION
## Summary
- Restyle the hero social links so they stop reading as a second nav row: lowercase labels (`github · twitter · linkedin`), `body2` size at `grey.500`, interpunct separators (`aria-hidden`), and an offset underline + lift to `text.primary` on hover instead of a color-only shift
- Align the links with the hero's monospace voice (same font stack as the typewriter subtitle); labels in `data/profile.ts` are untouched — lowercasing is CSS (`text-transform`)
- Switch the hero mono font stack from the unloaded JetBrains Mono to the `--font-geist-mono` variable actually loaded in `app/layout.tsx`, matching the blog code blocks (subtitle + social links now render in Geist Mono instead of the ui-monospace fallback)

## Test plan
- `npm run check` (lint / typecheck / test) — 4 files, 20 tests pass
- `npm run build` (static export) — pass
- Verified the hero on a local build: lowercase mono links with separators, subtitle in Geist Mono

🤖 Generated with [Claude Code](https://claude.com/claude-code)