### PR TITLE
Tokenize recurring typography values into the theme

### DIFF
--- a/app/blog/BlogList.tsx
+++ b/app/blog/BlogList.tsx
@@ -59,7 +59,6 @@ export function BlogList({ posts }: BlogListProps) {
                 textTransform: 'none',
                 color: 'text.primary',
                 fontWeight: 400,
-                letterSpacing: '-0.01em',
                 '&:hover': {
                   backgroundColor: 'transparent',
                   textDecoration: 'underline',

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Container, Box, Typography, Link as MuiLink } from '@mui/material';
 import type { Metadata } from 'next';
 import { siteConfig } from '@/config/site';
 import { hasOrchestraPlaceholders } from '@/lib/orchestra-widgets';
+import { fontFamilyMono } from '@/lib/theme';
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -118,7 +119,7 @@ export default async function BlogPost({ params }: PageProps) {
               '&:hover': { textDecoration: 'underline' },
             },
             '& code': {
-              fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+              fontFamily: fontFamilyMono,
               backgroundColor: 'rgba(255,255,255,0.06)',
               borderRadius: 1,
               px: 0.5,
@@ -130,7 +131,7 @@ export default async function BlogPost({ params }: PageProps) {
               borderRadius: 2,
               p: 2,
               overflowX: 'auto',
-              fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+              fontFamily: fontFamilyMono,
               color: 'text.primary',
             },
             '& ul, & ol': {

--- a/components/ActivitiesSection.tsx
+++ b/components/ActivitiesSection.tsx
@@ -100,14 +100,11 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
           return (
             <Box key={category}>
               <Typography
-                variant="h6"
+                variant="subtitle2"
                 component="h3"
                 sx={{
                   mb: 2,
-                  fontWeight: 500,
-                  letterSpacing: '-0.01em',
                   color: 'text.secondary',
-                  fontSize: '1rem'
                 }}
               >
                 {categoryLabels[category]}
@@ -131,11 +128,8 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
                       }}
                     >
                       <Typography
-                        variant="body1"
-                        sx={{
-                          fontWeight: 500,
-                          letterSpacing: '-0.01em'
-                        }}
+                        variant="subtitle1"
+                        component="p"
                       >
                         {activity.title}
                       </Typography>
@@ -172,7 +166,6 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
                           color="text.secondary"
                           sx={{
                             lineHeight: 1.7,
-                            letterSpacing: '-0.01em'
                           }}
                         >
                           {renderTextWithLinks(activity.description)}
@@ -195,7 +188,6 @@ export function ActivitiesSection({ activities, allActivities = [] }: Activities
               textTransform: 'none',
               color: 'text.primary',
               fontWeight: 400,
-              letterSpacing: '-0.01em',
               '&:hover': {
                 backgroundColor: 'transparent',
                 textDecoration: 'underline',

--- a/components/BlogPostCard.tsx
+++ b/components/BlogPostCard.tsx
@@ -24,7 +24,6 @@ export function BlogPostCard({ slug, title, date }: BlogPostCardProps) {
           component="h3"
           sx={{
             fontWeight: 600,
-            letterSpacing: '-0.01em',
             mb: 0.5,
             color: 'text.primary',
             '&:hover': {

--- a/components/CertificationsSection.tsx
+++ b/components/CertificationsSection.tsx
@@ -27,14 +27,11 @@ export function CertificationsSection({ content }: CertificationsSectionProps) {
   return (
     <Container maxWidth="md" component="section" sx={{ pt: 3, pb: 10 }}>
       <Typography
-        variant="h6"
+        variant="subtitle2"
         component="h3"
         sx={{
           mb: 2,
-          fontWeight: 500,
-          letterSpacing: '-0.01em',
           color: 'text.secondary',
-          fontSize: '1rem'
         }}
       >
         {content.title}
@@ -58,11 +55,8 @@ export function CertificationsSection({ content }: CertificationsSectionProps) {
               }}
             >
               <Typography
-                variant="body1"
-                sx={{
-                  fontWeight: 500,
-                  letterSpacing: '-0.01em'
-                }}
+                variant="subtitle1"
+                component="p"
               >
                 {certification.name}
               </Typography>
@@ -105,7 +99,6 @@ export function CertificationsSection({ content }: CertificationsSectionProps) {
                     color="text.secondary"
                     sx={{
                       lineHeight: 1.7,
-                      letterSpacing: '-0.01em',
                       fontVariantNumeric: 'tabular-nums'
                     }}
                   >

--- a/components/DynamicSubtitle.tsx
+++ b/components/DynamicSubtitle.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Box, Typography } from '@mui/material';
 import type { HeroSubtitle } from '@/types';
+import { fontFamilyMono } from '@/lib/theme';
 
 const HOLD_MS = 1800;
 const DELETE_MS = 60;
@@ -118,9 +119,8 @@ export function DynamicSubtitle({ content }: DynamicSubtitleProps) {
         color: 'text.secondary',
         mb: 3,
         fontWeight: 500,
-        letterSpacing: '-0.01em',
         minHeight: '1.6em',
-        fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+        fontFamily: fontFamilyMono,
       }}
     >
       <Box component="span" sx={{ whiteSpace: 'pre', color: 'text.primary' }}>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -10,7 +10,7 @@ type HeroSectionProps = {
 export function HeroSection({ content }: HeroSectionProps) {
   return (
     <Container maxWidth="md" component="section" sx={{ py: 6, textAlign: 'center' }}>
-      <Typography variant="h1" component="h1" gutterBottom sx={{ fontSize: { xs: '2rem', md: '2.5rem' }, mb: 3 }}>
+      <Typography variant="h1" component="h1" gutterBottom sx={{ mb: 3 }}>
         {content.title}
       </Typography>
       <DynamicSubtitle content={content.subtitle} />

--- a/components/PublicationsSection.tsx
+++ b/components/PublicationsSection.tsx
@@ -44,11 +44,8 @@ export function PublicationsSection({ publications }: PublicationsSectionProps) 
               }}
             >
               <Typography
-                variant="body1"
-                sx={{
-                  fontWeight: 500,
-                  letterSpacing: '-0.01em'
-                }}
+                variant="subtitle1"
+                component="p"
               >
                 {publication.title}
               </Typography>
@@ -67,7 +64,7 @@ export function PublicationsSection({ publications }: PublicationsSectionProps) 
             <Typography
               variant="body2"
               color="text.secondary"
-              sx={{ mt: 0.5, letterSpacing: '-0.01em' }}
+              sx={{ mt: 0.5 }}
             >
               {publication.authors.map((author, index) => (
                 <Box component="span" key={author}>
@@ -84,7 +81,7 @@ export function PublicationsSection({ publications }: PublicationsSectionProps) 
             <Typography
               variant="body2"
               color="text.secondary"
-              sx={{ mt: 0.25, letterSpacing: '-0.01em' }}
+              sx={{ mt: 0.25 }}
             >
               {publication.venue} ({typeLabels[publication.type]})
               {publication.links?.map((link) => (

--- a/components/SocialLinks.tsx
+++ b/components/SocialLinks.tsx
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 import Link from 'next/link';
 import { Box, Typography } from '@mui/material';
 import type { LabeledLink } from '@/types';
+import { fontFamilyMono } from '@/lib/theme';
 
 type SocialLinksProps = {
   links: LabeledLink[];
@@ -16,7 +17,7 @@ export function SocialLinks({ links }: SocialLinksProps) {
       alignItems="center"
       flexWrap="wrap"
       sx={{
-        fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+        fontFamily: fontFamilyMono,
       }}
     >
       {links.map((link, index) => (

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -2,6 +2,8 @@
 
 import { createTheme } from '@mui/material/styles';
 
+export const fontFamilyMono = 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace';
+
 export const theme = createTheme({
   palette: {
     mode: 'dark',
@@ -47,9 +49,13 @@ export const theme = createTheme({
   },
   typography: {
     fontFamily: 'var(--font-geist-sans), system-ui, sans-serif',
+    allVariants: {
+      letterSpacing: '-0.01em',
+    },
     h1: {
-      fontSize: '2.25rem',
       fontWeight: 700,
+      fontSize: '2rem',
+      '@media (min-width:900px)': { fontSize: '2.5rem' },
     },
     h2: {
       fontSize: '1.875rem',
@@ -58,6 +64,16 @@ export const theme = createTheme({
     h3: {
       fontSize: '1.5rem',
       fontWeight: 600,
+    },
+    subtitle1: {
+      fontSize: '1rem',
+      lineHeight: 1.6,
+      fontWeight: 500,
+    },
+    subtitle2: {
+      fontSize: '1rem',
+      lineHeight: 1.6,
+      fontWeight: 500,
     },
     body1: {
       fontSize: '1rem',


### PR DESCRIPTION
## Summary
- **Mono font stack**: export `fontFamilyMono` from `lib/theme.ts` and reference it from the hero subtitle, social links, and blog code blocks — replaces four copy-pasted font-stack strings
- **Letter spacing**: the site-wide `-0.01em` moves to `typography.allVariants`; twelve per-component `sx` repetitions deleted. Side effect (intentional): variants that previously lacked it (nav buttons, chips, captions, hero h1) now get the same tracking, making the voice uniform
- **Item titles**: `subtitle1` is now the 1rem / 500 / lineHeight 1.6 token; Certifications / Activities / Publications titles switch from `body1` + sx overrides to it, with `component="p"` pinned so the rendered tag doesn't change
- **Section headings**: `subtitle2` (previously unused) is now the 1rem / 500 section-heading token; Certifications / Activities headings switch to it. `h6` keeps its MUI default (1.25rem / 500) so card titles and empty states are untouched
- **Hero h1**: the responsive `2rem` → `2.5rem` size moves from an sx override into `typography.h1` (h1 is used only in the hero)

Left alone on purpose: the blog post page's markdown block keeps its own letter-spacing rule (`allVariants` only reaches MUI typography variants, not raw `dangerouslySetInnerHTML` tags), the deliberate `-0.02em` on the post title, one-off decorative values in the empty states, and everything under `components/orchestra/` (artwork-specific styling).

## Test plan
- `npm run check` (lint / typecheck / test) — 4 files, 20 tests pass
- `npm run build` (static export) — 39/39 pages generated
- Grep-verified: no `letterSpacing: '-0.01em'` or mono font-stack literals remain outside `lib/theme.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)